### PR TITLE
Remove automatic migration call

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -844,5 +844,3 @@ def migrate_conversation_history_table():
         print(f"Error al verificar/añadir la columna user_id: {str(e)}")
     finally:
         conn.close()
-
-migrate_conversation_history_table()


### PR DESCRIPTION
## Summary
- remove `migrate_conversation_history_table()` from module scope in `db_utils`
- migrations now run from `dashboard.py`

## Testing
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a464e1e9c8331b9632f3c0ebf274f