### PR TITLE
Fix agent variable names

### DIFF
--- a/agents/agentsscm.py
+++ b/agents/agentsscm.py
@@ -169,7 +169,7 @@ def delete_all_data():
     return db_utils.delete_all_data()
 
 # Create specialist agents
-Production_planner_Assistant = Agent(
+production_planner = Agent(
     name="production_planner",
     instructions="""
     You are a production planning specialist for a supply chain management system.
@@ -188,7 +188,7 @@ Production_planner_Assistant = Agent(
     tools=[get_daily_data, update_production_plan, get_production_summary, get_inventory_summary]
 )
 
-Demand_planner_Assistant = Agent(
+demand_planner = Agent(
     name="demand_planner",
     instructions="""
     You are a demand planning specialist for a supply chain management system.


### PR DESCRIPTION
## Summary
- rename `Production_planner_Assistant` to `production_planner`
- rename `Demand_planner_Assistant` to `demand_planner`
- confirm triage agent handoffs compile

## Testing
- `python -m py_compile agents/agentsscm.py`
- `python - <<'EOF'
import sys
sys.path.append('agents')
import agentsscm
print('production_planner' in dir(agentsscm))
print('demand_planner' in dir(agentsscm))
print('triage_agent' in dir(agentsscm))
print([agent.name for agent in agentsscm.triage_agent.handoffs])
EOF`

------
https://chatgpt.com/codex/tasks/task_e_685a6eebe3a08331b440ea818e9d68c8