### PR TITLE
Add stockout retrieval tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ The AI layer is built on top of the [OpenAI Agents SDK](https://openai.github.io
      – Data generation / purge ⇒ `data_generator`.
 
 2. **Production Planner (`production_planner`)**
-   • Tools:  
-     – `get_daily_data`  
-     – `update_production_plan`  
-     – `get_production_summary`  
-     – `get_inventory_summary`  
-   • Responsibilities: analyse production vs demand, adjust production plans, report inventory impact.
+   • Tools:
+      – `get_daily_data`
+      – `update_production_plan`
+      – `get_production_summary`
+      – `get_inventory_summary`
+      – `get_stockouts`
+   • Responsibilities: analyse production vs demand, adjust production plans, report inventory impact, and retrieve stockout days.
 
 3. **Demand Planner (`demand_planner`)**
    • Tools:  
@@ -93,6 +94,7 @@ The AI layer is built on top of the [OpenAI Agents SDK](https://openai.github.io
 | `get_production_summary()` | Aggregated stats on production. |
 | `get_demand_summary()` | Aggregated stats on demand. |
 | `get_inventory_summary()` | Aggregated stats on inventory. |
+| `get_stockouts()` | Retrieve all rows where inventory is zero or negative. |
 | `generate_future_data(start_date, days)` | Populates future records with random realistic values. |
 | `delete_all_data()` | Hard reset of the database. |
 

--- a/agents/agentsscm.py
+++ b/agents/agentsscm.py
@@ -136,6 +136,11 @@ def get_inventory_summary():
     return db_utils.get_inventory_summary()
 
 @function_tool
+def get_stockouts():
+    """Retrieve all rows with inventory at or below zero."""
+    return db_utils.get_stockouts()
+
+@function_tool
 def generate_future_data(start_date: str, days: int) -> Dict[str, Any]:
     """
     Generate random data for future dates and save to database.
@@ -179,13 +184,14 @@ production_planner = Agent(
       3. Providing summaries and insights about production patterns.
       4. Analyzing the relationship between demand and inventory.
       5. Updating production plan based on inventory levels.
-      6. When the user uses natural language date expressions (for example, "today", "tomorrow", "the next 10 days", "next week"), interpret the input using your date parsing tools.
-      7. If the message contains a date range (for example, "from April 1st to April 5th", "the next 10 days"), explicitly determine the start and end of the range.
-      8. IMPORTANT: You have access to the conversation history, so you can refer to previous messages
+      6. Retrieving all stockouts (days where inventory is zero or negative).
+      7. When the user uses natural language date expressions (for example, "today", "tomorrow", "the next 10 days", "next week"), interpret the input using your date parsing tools.
+      8. If the message contains a date range (for example, "from April 1st to April 5th", "the next 10 days"), explicitly determine the start and end of the range.
+      9. IMPORTANT: You have access to the conversation history, so you can refer to previous messages
     and maintain context throughout the conversation.
     """,
     model="gpt-4o",
-    tools=[get_daily_data, update_production_plan, get_production_summary, get_inventory_summary]
+    tools=[get_daily_data, update_production_plan, get_production_summary, get_inventory_summary, get_stockouts]
 )
 
 demand_planner = Agent(

--- a/db_utils.py
+++ b/db_utils.py
@@ -306,6 +306,21 @@ def get_inventory_summary():
     finally:
         conn.close()
 
+def get_stockouts() -> List[Dict[str, Any]]:
+    """Retrieve rows where inventory is zero or negative."""
+    conn = get_connection()
+    try:
+        cursor = conn.cursor()
+        query = (
+            "SELECT date, demand, production_plan, inventory FROM daily_data "
+            "WHERE inventory <= 0 ORDER BY date"
+        )
+        cursor.execute(query)
+        columns = [desc[0] for desc in cursor.description]
+        return [dict(zip(columns, row)) for row in cursor.fetchall()]
+    finally:
+        conn.close()
+
 def generate_future_data(start_date: str, days: int) -> str:
     """
     Generate random data for future dates and save to database.


### PR DESCRIPTION
## Summary
- expose `get_stockouts()` in `db_utils` to fetch zero or negative inventory
- add `get_stockouts` tool in `agents/agentsscm` and mention it in production_planner instructions
- document `get_stockouts` in README

## Testing
- `python -m py_compile db_utils.py agents/agentsscm.py`

------
https://chatgpt.com/codex/tasks/task_e_685aa7ec37c8833197c1eda53aefc043