### PR TITLE
Add custom styling for metrics and DataTable

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,8 @@
+.metric-number {
+  font-size: 2rem;
+  font-weight: bold;
+}
+
+.datatable-cell {
+  font-size: 1.2rem;
+}


### PR DESCRIPTION
## Summary
- create `assets/style.css` with metric-number and datatable-cell styles
- import `dash_table` and add helper `create_metric_cards`
- show metric cards and a `DataTable` with new CSS classes in dashboard

## Testing
- `python -m py_compile dashboard/dashboard.py chatbot.py db_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685aaf2e88e0833182e123effe594369