### PR TITLE
Add forecast column support

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -389,8 +389,8 @@ def render_content(tab, n_clicks):
     try:
         cursor = conn.cursor()
         if tab == 'tab-1':
-            # Modified SQL query to specify column order with inventory at the end
-            cursor.execute("SELECT date, demand, production_plan, inventory FROM daily_data")
+            # Modified SQL query to specify column order including forecast
+            cursor.execute("SELECT date, demand, production_plan, forecast, inventory FROM daily_data")
             data = cursor.fetchall()
             columns = [desc[0] for desc in cursor.description]
 
@@ -559,6 +559,7 @@ chatbot.register_callbacks(app)
 migrate_users_table_if_needed()
 # Ejecutar la migración de la tabla conversation_history para añadir la columna user_id si no existe
 db_utils.migrate_conversation_history_table()
+db_utils.ensure_forecast_column()
 
 if __name__ == '__main__':
     # Use standard configuration for local development


### PR DESCRIPTION
## Summary
- add helper to ensure `forecast` column on startup
- generate random forecast data when creating future rows
- expose an `update_forecast` helper
- fetch and display forecast data on dashboard

## Testing
- `python -m py_compile db_utils.py dashboard/dashboard.py`
- `python -m py_compile forecast_utils.py agents/agentsscm.py chatbot.py`

------
https://chatgpt.com/codex/tasks/task_e_685b8dc6aabc83318f638cc2a6580297