### PR TITLE
Normalize SQLite dates to ISO format

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,9 +108,8 @@ The AI layer is built on top of the [OpenAI Agents SDK](https://openai.github.io
 
 #### Date & Database Abstraction
 
-All functions rely on `db_utils.parse_date()` to normalise natural-language dates into:  
-• `DD-MM-YYYY` for SQLite (local)  
-• `YYYY-MM-DD` for PostgreSQL (Railway)
+All functions rely on `db_utils.parse_date()` to normalise natural-language dates
+into the `YYYY-MM-DD` format for both SQLite and PostgreSQL.
 
 The database access layer automatically switches between SQLite and PostgreSQL based on the presence of the `DATABASE_URL` environment variable and adapts SQL placeholders (`?` vs `%s`) accordingly.
 

--- a/agents/agentsscm.py
+++ b/agents/agentsscm.py
@@ -29,9 +29,8 @@ def get_daily_data(date: Optional[str] = None) -> List[Dict[str, Any]]:
     # Si se proporciona una fecha, se procesa y se formatea correctamente
     if date:
         try:
-            # Esta función se encarga de interpretar la fecha y devolver el formato adecuado:
-            # Para PostgreSQL (Railway) será "YYYY-MM-DD"
-            # Para SQLite, "DD-MM-YYYY"
+            # Esta función se encarga de interpretar la fecha y devolverla en el
+            # formato ISO "YYYY-MM-DD" para ambos motores de base de datos
             formatted_date = db_utils.parse_date(date)
         except ValueError as e:
             return {"error": str(e)}
@@ -239,7 +238,7 @@ data_generator = Agent(
     
     When asked to generate data:
       - Confirm the start date and number of days.
-      - Use the DD-MM-YYYY format for dates (e.g., "18-04-2025").
+      - Use the YYYY-MM-DD format for dates (e.g., "2025-04-18").
       - Explain what data was generated and how it can be used.
     
     When asked to delete all data:


### PR DESCRIPTION
## Summary
- return ISO format from `parse_date`
- always use YYYY-MM-DD when generating future data
- add a helper to convert existing SQLite records
- update agent instructions and README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- run a manual SQLite conversion demo

------
https://chatgpt.com/codex/tasks/task_e_685ba1d8fb1883319bf79f40d8ec3295