### PR TITLE
Make chat widget background translucent

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -172,6 +172,8 @@ def create_chat_components():
                 "zIndex": "1001",
                 "boxShadow": "0 4px 20px rgba(0,0,0,0.15)",
                 "borderRadius": "15px",
+                "backgroundColor": "rgba(255, 255, 255, 0.85)",
+                "backdropFilter": "blur(4px)",
                 "display": "none",  # Initially hidden
                 "transition": "all 0.3s ease"
             },


### PR DESCRIPTION
## Summary
- enhance chat modal style for more transparency

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dateparser')*

------
https://chatgpt.com/codex/tasks/task_e_685ba82f75808331ba806c1a77e00f76