### PR TITLE
Update dashboard inventory metric

### DIFF
--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -402,6 +402,7 @@ def render_content(tab, n_clicks):
             prod_summary = db_utils.get_production_summary()
             demand_summary = db_utils.get_demand_summary()
             inv_summary = db_utils.get_inventory_summary()
+            projected_inventory = db_utils.get_latest_inventory()
 
             metrics = dbc.Row([
                 dbc.Col(
@@ -420,8 +421,8 @@ def render_content(tab, n_clicks):
                 ),
                 dbc.Col(
                     dbc.Card([
-                        dbc.CardHeader("Total Inventory"),
-                        dbc.CardBody(html.Div(inv_summary.get("total_inventory", 0), className="metric-number"))
+                        dbc.CardHeader("Projected Inventory"),
+                        dbc.CardBody(html.Div(projected_inventory, className="metric-number"))
                     ], body=True, className="text-center"),
                     md=4
                 )

--- a/db_utils.py
+++ b/db_utils.py
@@ -264,13 +264,24 @@ def get_inventory_summary():
             cursor.execute("SELECT SUM(inventory), AVG(inventory), MIN(inventory), MAX(inventory) FROM daily_data")
         
         total, avg, min_val, max_val = cursor.fetchone()
-        
+
         return {
             "total_inventory": int(total) if total is not None else 0,
             "average_inventory": round(float(avg), 2) if avg is not None else 0,
             "min_inventory": int(min_val) if min_val is not None else 0,
             "max_inventory": int(max_val) if max_val is not None else 0
         }
+    finally:
+        conn.close()
+
+def get_latest_inventory() -> int:
+    """Return the inventory value for the most recent date."""
+    conn = get_connection()
+    try:
+        cursor = conn.cursor()
+        cursor.execute("SELECT inventory FROM daily_data ORDER BY date DESC LIMIT 1")
+        row = cursor.fetchone()
+        return int(row[0]) if row else 0
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
- add `get_latest_inventory` helper
- display latest inventory value instead of total
- rename the metric to "Projected Inventory"

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bb430f194833193a4460eb99cb9ae