### PR TITLE
Add forecast start date support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ The AI layer is built on top of the [OpenAI Agents SDK](https://openai.github.io
 | `generate_future_data(start_date, days)` | Populates future records with random realistic values. |
 | `increase_all_demand(offset)` | Adds an offset to demand across all dates and recalculates inventory. |
 | `clear_all_forecast()` | Sets all forecast values to NULL without deleting any rows. |
+| `calculate_demand_forecast(method?, periods?, start_date?)` | Compute and store a forecast. If `start_date` is omitted the forecast begins after the last known date. |
 | `delete_all_data()` | Hard reset of the database. |
 
 #### Conversation & Memory
@@ -146,6 +147,7 @@ The application uses SQLite to store supply chain data. The database includes:
 - Triage routing extended so forecast-clearing requests reach the Demand Planner.
 - Unified date handling: all functions produce `YYYY-MM-DD` regardless of backend.
 - Inventory recalculates cumulatively whenever production or demand is changed.
+- Forecast functions can now start from a custom date via `calculate_demand_forecast(start_date=...)`.
 
 ## License
 

--- a/agents/agentsscm.py
+++ b/agents/agentsscm.py
@@ -99,22 +99,44 @@ def get_demand_summary():
     return db_utils.get_demand_summary()
 
 @function_tool
-def calculate_demand_forecast(method: str = "exponential_smoothing", periods: int = 7) -> Dict[str, Any]:
-    """Calculate demand forecast using historical data and persist to the database."""
-    if method == "moving_average":
-        forecast = forecast_utils.moving_average_forecast(periods=periods)
+def calculate_demand_forecast(
+    method: str = "exponential_smoothing",
+    periods: int = 7,
+    start_date: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Calculate demand forecast and persist it to the database.
+
+    If ``start_date`` is provided, the forecast begins on that date using
+    historical data up to and including that day. Otherwise the forecast starts
+    after the latest date present in the database.
+    """
+
+    if start_date:
+        try:
+            formatted_start = db_utils.parse_date(start_date)
+        except ValueError as e:
+            return {"error": str(e)}
+        forecast = forecast_utils.forecast_from_date(
+            formatted_start, periods, method=method
+        )
     else:
-        forecast = forecast_utils.exponential_smoothing_forecast(periods=periods)
+        if method == "moving_average":
+            forecast = forecast_utils.moving_average_forecast(periods=periods)
+        else:
+            forecast = forecast_utils.exponential_smoothing_forecast(periods=periods)
 
     if not forecast:
         return {"error": "No demand data available for forecasting"}
 
-    # Determine the start date based on the latest existing record
+    # Determine the start date for persisting the forecast
     data = db_utils.get_daily_data()
     if data:
-        last_date_str = max(row["date"] for row in data)
-        last_date = datetime.strptime(last_date_str, "%Y-%m-%d")
-        next_date = last_date + timedelta(days=1)
+        if start_date:
+            next_date = datetime.strptime(formatted_start, "%Y-%m-%d")
+        else:
+            last_date_str = max(row["date"] for row in data)
+            last_date = datetime.strptime(last_date_str, "%Y-%m-%d")
+            next_date = last_date + timedelta(days=1)
 
         for value in forecast:
             db_utils.update_forecast(next_date.strftime("%Y-%m-%d"), int(value))

--- a/forecast_utils.py
+++ b/forecast_utils.py
@@ -33,3 +33,46 @@ def exponential_smoothing_forecast(alpha: float = 0.5, periods: int = 7) -> List
     )
     forecast = model.forecast(periods)
     return [round(val, 2) for val in forecast.tolist()]
+
+
+def forecast_from_date(
+    start_date: str,
+    periods: int,
+    method: str = "exponential_smoothing",
+    alpha: float = 0.5,
+    window: int = 3,
+) -> List[float]:
+    """Forecast demand beginning from ``start_date`` using the chosen method.
+
+    The forecast uses all data up to and including ``start_date`` as the
+    history. Supported methods are ``"exponential_smoothing"`` (default) and
+    ``"moving_average"``.
+    """
+
+    data = db_utils.get_daily_data()
+    if not data:
+        return []
+
+    try:
+        iso_date = db_utils.parse_date(start_date)
+    except ValueError:
+        return []
+
+    history = [row["demand"] for row in data if row["date"] <= iso_date]
+    if not history:
+        return []
+    series = pd.Series(history)
+
+    if method == "moving_average":
+        if len(series) < window:
+            window = len(series)
+        last_ma = series.rolling(window=window).mean().iloc[-1]
+        forecast = [round(last_ma, 2)] * periods
+    else:
+        model = SimpleExpSmoothing(series, initialization_method="heuristic").fit(
+            smoothing_level=alpha, optimized=False
+        )
+        forecast = [round(val, 2) for val in model.forecast(periods).tolist()]
+
+    return forecast
+

--- a/tests/test_forecast_db.py
+++ b/tests/test_forecast_db.py
@@ -81,3 +81,38 @@ def test_calculate_demand_forecast_updates_future_rows(monkeypatch):
 
     int_expected = [int(x) for x in expected]
     assert [f1, f2, f3] == int_expected
+
+
+def test_calculate_demand_forecast_with_start_date(monkeypatch):
+    original_get_daily_data = db_utils.get_daily_data
+
+    def limited_get_daily_data(date=None):
+        data = original_get_daily_data(date)
+        if date is None:
+            return [row for row in data if row['date'] <= '2024-01-10']
+        return data
+
+    monkeypatch.setattr(db_utils, "get_daily_data", limited_get_daily_data)
+
+    expected = forecast_utils.forecast_from_date("2024-01-11", periods=2)
+
+    import json, asyncio
+    result = asyncio.run(
+        agentsscm.calculate_demand_forecast.on_invoke_tool(
+            None,
+            json.dumps({"periods": 2, "start_date": "2024-01-11"}),
+        )
+    )
+
+    assert result["forecast"] == expected
+
+    conn = db_utils.get_connection()
+    cur = conn.cursor()
+    cur.execute("SELECT forecast FROM daily_data WHERE date = ?", ('2024-01-11',))
+    f1 = cur.fetchone()[0]
+    cur.execute("SELECT forecast FROM daily_data WHERE date = ?", ('2024-01-12',))
+    f2 = cur.fetchone()[0]
+    conn.close()
+
+    int_expected = [int(x) for x in expected]
+    assert [f1, f2] == int_expected


### PR DESCRIPTION
## Summary
- extend `forecast_utils` with `forecast_from_date`
- update `calculate_demand_forecast` tool to take optional `start_date`
- document new argument and note feature in recent updates
- add regression test for forecasting from a custom date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68681232757c8331b7a2dee5ff430404