### PR TITLE
Handle early start dates in forecasts

### DIFF
--- a/forecast_utils.py
+++ b/forecast_utils.py
@@ -58,7 +58,12 @@ def forecast_from_date(
     except ValueError:
         return []
 
-    history = [row["demand"] for row in data if row["date"] <= iso_date]
+    earliest_date = min(row["date"] for row in data)
+    if iso_date < earliest_date:
+        iso_date = earliest_date
+        history = [row["demand"] for row in data]
+    else:
+        history = [row["demand"] for row in data if row["date"] <= iso_date]
     if not history:
         return []
     series = pd.Series(history)

--- a/tests/test_forecast_db.py
+++ b/tests/test_forecast_db.py
@@ -144,3 +144,8 @@ def test_clear_forecast_range():
 
     assert f11 == 10
     assert f12 is None and f13 is None
+
+
+def test_forecast_from_date_before_dataset():
+    forecast = forecast_utils.forecast_from_date("2023-12-25", periods=2)
+    assert len(forecast) > 0


### PR DESCRIPTION
## Summary
- prevent `forecast_from_date` from returning empty data by using earliest dataset date
- ensure full dataset is used when start date precedes the data range
- test requesting a forecast from before the dataset

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6868f58766748331a3cee5425b8a725c