### PR TITLE
Clarify forecast parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The application relies on the following core technologies:
 1. Run `python dashboard/dashboard.py` to start the dashboard application.
 2. Access the dashboard in your web browser at [http://127.0.0.1:8050/](http://127.0.0.1:8050/)
 3. Use the chat interface to interact with the AI assistant
-4. When requesting forecasts or data updates, the agent will summarise the chosen calculation method and parameters, then ask for your confirmation before executing.
+4. When requesting forecasts or data updates, the agent summarises the chosen calculation method and parameters. If you didn't specify details like the forecasting method or number of periods, the assistant will ask follow-up questions to gather that information and then request your confirmation before executing.
 5. To generate a forecast and production plan in one step, type `/forecast-plan: <your question>` in the chat.
 
 ## AI Agents

--- a/agents/agentsscm.py
+++ b/agents/agentsscm.py
@@ -276,9 +276,14 @@ demand_planner = Agent(
       2. Calculate demand forecast using calculate_demand_forecast tool.
       3. Providing summaries and insights about demand patterns.
       4. **Before running any forecast, modifying demand values, or clearing forecast data, create a clear plan (e.g., list of dates that will become `NULL` for forecast) and ask the user to confirm before executing.**
-      5. When the user uses natural language date expressions (for example, "today", "tomorrow", "the next 10 days", "next week"), interpret the input using your date parsing tools.
-      6. If the message contains a date range (for example, "from April 1st to April 5th", "the next 10 days"), explicitly determine the start and end of the range.
-      7. IMPORTANT: You have access to the conversation history, so you can refer to previous messages
+     5. If the user requests a forecast without specifying the parameters, ask clarifying questions about:
+         - the forecasting method (e.g. `exponential_smoothing` or `moving_average`)
+         - the number of periods to project
+         - any start date to begin the forecast
+       Confirm these values before calculating the forecast.
+      6. When the user uses natural language date expressions (for example, "today", "tomorrow", "the next 10 days", "next week"), interpret the input using your date parsing tools.
+      7. If the message contains a date range (for example, "from April 1st to April 5th", "the next 10 days"), explicitly determine the start and end of the range.
+      8. IMPORTANT: You have access to the conversation history, so you can refer to previous messages
     and maintain context throughout the conversation.
     """,
     model="gpt-4o",


### PR DESCRIPTION
## Summary
- demand planner now prompts for forecast method, start date and number of periods if missing
- document that the assistant will ask follow-up questions

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686939e3dfcc83318253542ed466ba44