### PR TITLE
Improve forecast range clearing

### DIFF
--- a/db_utils.py
+++ b/db_utils.py
@@ -274,6 +274,35 @@ def clear_forecast_range(start_date: str, end_date: Optional[str] = None) -> str
     conn = get_connection()
     try:
         cursor = conn.cursor()
+        # Check if any forecast values exist for the given range
+        if iso_end:
+            if IS_RAILWAY:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM daily_data WHERE date >= %s AND date <= %s AND forecast IS NOT NULL",
+                    (iso_start, iso_end),
+                )
+            else:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM daily_data WHERE date >= ? AND date <= ? AND forecast IS NOT NULL",
+                    (iso_start, iso_end),
+                )
+        else:
+            if IS_RAILWAY:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM daily_data WHERE date >= %s AND forecast IS NOT NULL",
+                    (iso_start,),
+                )
+            else:
+                cursor.execute(
+                    "SELECT COUNT(*) FROM daily_data WHERE date >= ? AND forecast IS NOT NULL",
+                    (iso_start,),
+                )
+
+        count = cursor.fetchone()[0]
+        if count == 0:
+            return "No forecast values found in the specified date range."
+
+        # Clear the forecast values only if records were found
         if iso_end:
             if IS_RAILWAY:
                 cursor.execute(

--- a/tests/test_forecast_db.py
+++ b/tests/test_forecast_db.py
@@ -146,6 +146,20 @@ def test_clear_forecast_range():
     assert f12 is None and f13 is None
 
 
+def test_clear_forecast_range_no_records():
+    """Return informative message when no forecast data exists for range."""
+
+    import json, asyncio
+    result = asyncio.run(
+        agentsscm.clear_forecast_range.on_invoke_tool(
+            None,
+            json.dumps({"start_date": "2025-01-01", "end_date": "2025-01-05"}),
+        )
+    )
+
+    assert result["message"] == "No forecast values found in the specified date range."
+
+
 def test_forecast_from_date_before_dataset():
     forecast = forecast_utils.forecast_from_date("2023-12-25", periods=2)
     assert len(forecast) > 0


### PR DESCRIPTION
## Summary
- check if forecast values exist before clearing a range
- add test verifying an informative message when no records exist

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693944c8588331ab190365fdf82e3f