### PR TITLE
Fix cross-DB date comparison

### DIFF
--- a/forecast_utils.py
+++ b/forecast_utils.py
@@ -58,12 +58,14 @@ def forecast_from_date(
     except ValueError:
         return []
 
-    earliest_date = min(row["date"] for row in data)
+    earliest_date = min(str(row["date"]) for row in data)
     if iso_date < earliest_date:
         iso_date = earliest_date
         history = [row["demand"] for row in data]
     else:
-        history = [row["demand"] for row in data if row["date"] <= iso_date]
+        history = [
+            row["demand"] for row in data if str(row["date"]) <= iso_date
+        ]
     if not history:
         return []
     series = pd.Series(history)


### PR DESCRIPTION
## Summary
- ensure `forecast_from_date` converts DB dates to strings for comparisons

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68693e081c34833194f178c02de5c9c2