### PR TITLE
Fix debug toggle for Dash Bootstrap Components 2.x

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -111,12 +111,11 @@ def create_chat_components():
                                         className="me-2",
                                         style={"fontSize": "0.9rem"}
                                     ),
-                                    dbc.Checkbox(
+                                    dbc.Switch(
                                         id="debug-checkbox",
                                         value=False,
                                         label="Debug",
                                         className="me-2",
-                                        switch=True,
                                     ),
                                     dbc.Button(
                                         "×",


### PR DESCRIPTION
## Summary
- use `dbc.Switch` instead of deprecated `dbc.Checkbox` for debug mode

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `python -m dashboard.dashboard` *(fails: no such table `information_schema.columns`, but server starts)*

------
https://chatgpt.com/codex/tasks/task_e_68696c66a3c88331a35e7521e3a6ca23