### PR TITLE
Enable debug streaming for forecast-plan workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The application relies on the following core technologies:
 3. Use the chat interface to interact with the AI assistant
 4. When requesting forecasts or data updates, the agent summarises the chosen calculation method and parameters. If you didn't specify details like the forecasting method or number of periods, the assistant will ask follow-up questions to gather that information and then request your confirmation before executing.
 5. To generate a forecast and production plan in one step, type `/forecast-plan: <your question>` in the chat.
-6. Enable the **Debug** checkbox in the chat window to stream step-by-step details of the agent's execution.
+6. Enable the **Debug** checkbox in the chat window to stream step-by-step details of the agent's execution. When using `/forecast-plan:` the debug output includes events from both planners.
 
 ## AI Agents
 

--- a/chatbot.py
+++ b/chatbot.py
@@ -382,10 +382,21 @@ def register_callbacks(app):
 
             if user_input.lower().startswith('/forecast-plan:'):
                 question = user_input.split(':', 1)[1].strip()
-                result_text = loop.run_until_complete(orchestrate_forecast_to_plan(question))
+                if debug:
+                    result_text, debug_events = loop.run_until_complete(
+                        orchestrate_forecast_to_plan(question, debug=True)
+                    )
+                else:
+                    result_text = loop.run_until_complete(
+                        orchestrate_forecast_to_plan(question, debug=False)
+                    )
                 loop.close()
+
                 messages[-1]["content"] = result_text
                 messages[-1]["time"] = datetime.now().strftime("%H:%M")
+                if debug:
+                    messages.extend(handle_debug_events(debug_events))
+
                 if user_authenticated:
                     db_utils.save_message_with_user(user_id, session_id, "assistant", result_text)
                 else:


### PR DESCRIPTION
## Summary
- allow `orchestrate_forecast_to_plan` to stream events when debug mode is on
- propagate debug flag in chatbot and show streamed events
- document combined debug output when using `/forecast-plan:`
- test debug event storage for forecast-plan command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686972ea18388331a073cf1a37610604