### PR TITLE
Fix debug messages in conversation history

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -429,7 +429,11 @@ def register_callbacks(app):
                 return chat_history, "", conversation_data, ""
 
             # Pass the entire conversation history to the agent
-            conversation_history = [{"role": msg["role"], "content": msg["content"]} for msg in messages[:-1]]  # Exclude the placeholder
+            conversation_history = [
+                {"role": msg["role"], "content": msg["content"]}
+                for msg in messages[:-1]
+                if msg.get("role") != "debug"
+            ]  # Exclude placeholder and debug messages
 
             if debug:
 


### PR DESCRIPTION
## Summary
- filter `debug` messages from `conversation_history` when invoking the agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697c65d3e8833183d2d607ff1757e3