### PR TITLE
Reduce noisy debug logs

### DIFF
--- a/chatbot.py
+++ b/chatbot.py
@@ -239,7 +239,9 @@ def handle_debug_events(events):
         if isinstance(ev, RawResponsesStreamEvent):
             delta = getattr(ev.data, "delta", None)
             text = getattr(delta, "content", None) or getattr(ev.data, "text", None)
-            content = f"📝 Modelo envía: {text}" if text else "📝 Evento de modelo"
+            if not text:
+                continue
+            content = f"📝 Modelo envía: {text}"
         elif isinstance(ev, RunItemStreamEvent):
             if ev.name == "tool_called":
                 tool_name = getattr(ev.item, "raw_item", getattr(ev.item, "tool", None))

--- a/tests/test_debug_mode.py
+++ b/tests/test_debug_mode.py
@@ -45,7 +45,7 @@ def test_process_user_message_debug(monkeypatch):
     chat_history, _, conv_data, _ = process_msg(1, None, {}, {"session_id": "s1"}, "hello", {"messages": [], "session_id": "s1"}, True)
 
     debug_msgs = [m for m in conv_data["messages"] if m["role"] == "debug"]
-    assert len(debug_msgs) == 2
+    assert len(debug_msgs) == 1
 
 
 def test_forecast_plan_debug(monkeypatch):


### PR DESCRIPTION
## Summary
- ignore empty model events in debug output
- update debug unit test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869824482a88331976e978fb5ae85fc